### PR TITLE
Add Ansible setup and mark shell scripts as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,35 +56,27 @@ This repository contains my personal dotfiles and configurations for various env
    * functions/: Contains categorized function scripts, organized into subdirectories.
    * scripts/: Contains scripts that can be sourced or executed directly.
 * bin/: Contains executable scripts that are added to your PATH for global access.
-* install.sh: Script to set up the dotfiles by installing necessary packages and creating symlinks using stow.
+* install.sh, setup_linux.sh and setup_windows.sh: Deprecated shell scripts kept for reference.
 * oh-my-posh/: Contains oh-my-posh themes and configurations.
-* setup_linux.sh and setup_windows.sh: Setup scripts for Linux and Windows environments, respectively.
+* setup.yml: Primary Ansible playbook for setting up the environment.
 * README.md: This file.
 
 ## Setup Instructions
 
-### Linux Fresh Install
-1. Clone the Repository
-   ```bash
-   git clone https://github.com/setuc/dotfiles.git ~/.dotfiles  
-   ```
-2. Navigate to the Directory
-   ```bash
-   cd ~/.dotfiles  
-   ```
-3. Make Scripts Executable
-   ```bash
-   chmod +x install.sh setup_linux.sh
-   ```
-4. Run the Install Script
-   ```bash
-   ./install.sh  
-   ```
-5. Run the Linux Setup Script
-   ```bash
-   ../setup_linux.sh 
-   ```
+### Ansible Setup (recommended)
+1. Install Ansible (e.g. `sudo apt install ansible`).
+2. Clone the repository
+```bash
+git clone https://github.com/setuc/dotfiles.git ~/.dotfiles
+cd ~/.dotfiles
+```
+3. Run the playbook
+```bash
+ansible-playbook -i localhost, -c local setup.yml
+```
 
+### Legacy Shell Scripts
+Legacy scripts (install.sh, setup_linux.sh, setup_windows.sh) are deprecated and kept only for reference.
 ### Setting Up Oh My Posh
 Oh My Posh is initialized in the ```~/.bashrc``` file. The theme used is night-owl.omp.json, located in the ```oh-my-posh/themes/``` directory.
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# DEPRECATED: use the setup.yml Ansible playbook instead.
 #
 # setup_linux_all_in_one.sh
 # -------------------------

--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,5 @@
 #!/bin/bash  
+# DEPRECATED: use the setup.yml Ansible playbook instead.
   
 # Function to check if a command exists  
 command_exists() {  

--- a/setup.yml
+++ b/setup.yml
@@ -1,0 +1,40 @@
+---
+- hosts: localhost
+  gather_facts: yes
+  vars:
+    software_list: "{{ lookup('file', 'software_list.json') | from_json }}"
+    dotfiles_dir: "{{ playbook_dir }}"
+  tasks:
+    - name: Install apt packages
+      become: yes
+      apt:
+        name: "{{ item.value.apt }}"
+        state: present
+      when:
+        - item.value.apt is defined
+        - item.value.apt != 'custom'
+      loop: "{{ software_list | dict2items }}"
+
+    - name: Run custom install commands
+      become: yes
+      shell: "{{ item.value.custom_install }}"
+      args:
+        executable: /bin/bash
+      when:
+        - item.value.custom_install is defined
+        - item.value.apt == 'custom'
+      loop: "{{ software_list | dict2items }}"
+
+    - name: Ensure Stow is installed
+      become: yes
+      apt:
+        name: stow
+        state: present
+
+    - name: Stow dotfiles
+      shell: |
+        stow --verbose --restow --dir={{ dotfiles_dir }} --target=$HOME bash bin oh-my-posh
+      args:
+        chdir: "{{ dotfiles_dir }}"
+        executable: /bin/bash
+

--- a/setup_linux.sh
+++ b/setup_linux.sh
@@ -1,4 +1,5 @@
 #!/bin/bash  
+# DEPRECATED: use the setup.yml Ansible playbook instead.
   
 # Setup script for Linux environment  
   

--- a/setup_windows.sh
+++ b/setup_windows.sh
@@ -1,3 +1,4 @@
+# DEPRECATED: use the setup.yml Ansible playbook instead.
 # Setup script for Windows environment using winget and JSON list
 
 # Read the software list


### PR DESCRIPTION
## Summary
- create `setup.yml` playbook for unified setup
- document Ansible approach in README
- mark legacy shell scripts as deprecated

## Testing
- `ansible-playbook --syntax-check setup.yml`

------
https://chatgpt.com/codex/tasks/task_e_684043f52dac832c897ce0eb44370c67