### PR TITLE
Fix stow conflicts and clarify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,10 +72,21 @@ cd ~/.dotfiles
 ```
 3. Run the playbook
 ```bash
-ansible-playbook -i localhost, -c local setup.yml
+ansible-playbook -i localhost, -c local --ask-become-pass setup.yml
 ```
 Run this command as your regular user; the playbook elevates privileges only
-when needed for package installation.
+when needed for package installation. The `--ask-become-pass` flag prompts for
+your sudo password; omit it if you have passwordless sudo.
+
+If you already have a `~/.bashrc` file, Stow may report conflicts. Back it up
+before running the playbook:
+
+```bash
+mv ~/.bashrc ~/.bashrc.backup
+```
+Stow can also fail on WSL if you have symlinks like `~/.aws` or `~/.azure`
+pointing to Windows paths. Temporarily move those out of the way if you see
+`Absolute/relative mismatch` errors.
 
 This playbook installs Oh My Posh into `~/bin`. The directory is created
 automatically if it does not already exist.
@@ -117,8 +128,10 @@ This repository includes an Ansible playbook that can configure the local machin
    ```
 2. Execute the playbook
    ```bash
-   ansible-playbook -i 'localhost,' -c local ansible/site.yml
+   ansible-playbook -i 'localhost,' -c local --ask-become-pass setup.yml
    ```
+   The `--ask-become-pass` flag prompts for your sudo password; omit it if you
+   have passwordless sudo.
 
 ### Run Against Remote Hosts
 

--- a/setup.yml
+++ b/setup.yml
@@ -37,6 +37,29 @@
         name: stow
         state: present
 
+    - name: Check if ~/.bashrc exists and is not a symlink
+      ansible.builtin.stat:
+        path: "{{ ansible_env.HOME }}/.bashrc"
+        follow: false
+      register: bashrc_stat
+
+    - name: Backup existing ~/.bashrc
+      ansible.builtin.copy:
+        src: "{{ ansible_env.HOME }}/.bashrc"
+        dest: "{{ ansible_env.HOME }}/.bashrc.backup"
+        remote_src: true
+      when:
+        - bashrc_stat.stat.exists
+        - not bashrc_stat.stat.islnk
+
+    - name: Remove ~/.bashrc to avoid stow conflicts
+      ansible.builtin.file:
+        path: "{{ ansible_env.HOME }}/.bashrc"
+        state: absent
+      when:
+        - bashrc_stat.stat.exists
+        - not bashrc_stat.stat.islnk
+
     - name: Stow dotfiles
       ansible.builtin.shell: |
         stow --verbose --restow --dir={{ dotfiles_dir }} --target=$HOME bash bin oh-my-posh


### PR DESCRIPTION
## Summary
- handle existing `.bashrc` before stowing in `setup.yml`
- document potential stow conflicts on WSL
- use `setup.yml` consistently in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68404eda2c8c832cb94fe5a55c2e3857