### PR TITLE
Install uv package manager via Ansible

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,9 @@ pointing to Windows paths. Temporarily move those out of the way if you see
 This playbook installs Oh My Posh into `~/bin`. The directory is created
 automatically if it does not already exist.
 
+The setup also installs Astral's `uv` package manager using its official
+installation script, which places the binary in `~/.local/bin` by default.
+
 ### Legacy Shell Scripts
 Legacy scripts (install.sh, setup_linux.sh, setup_windows.sh) are deprecated and kept only for reference.
 ### Setting Up Oh My Posh
@@ -112,6 +115,7 @@ These initializations are placed in ```~/.bash_exports```, which is sourced by `
 ## Usage
 
 * **Aliases**: All aliases are organized in the bash/aliases/ directory and are sourced in ~/.bash_aliases.
+  * The `uv.aliases` file provides handy shortcuts for Astral's uv package manager, such as `uvs` for `uv sync` and `uvps` for `uv pip sync`.
 * **Functions**: Functions are categorized and placed in bash/functions/ and its subdirectories. They are sourced in ~/.bash_functions.
 * **Scripts**: Executable scripts are located in the bin/ directory, which is added to your PATH.
 Notes

--- a/bash/aliases/uv.aliases
+++ b/bash/aliases/uv.aliases
@@ -1,0 +1,5 @@
+# uv aliases
+alias uvs='uv sync'
+alias uvp='uv pip'
+alias uvpi='uv pip install'
+alias uvps='uv pip sync'

--- a/software_list.json
+++ b/software_list.json
@@ -29,5 +29,11 @@
         "winget": "OpenJS.NodeJS",
         "apt": "nodejs",
         "default": false
+    },
+    "uv": {
+        "description": "Blazingly fast Python package manager from Astral",
+        "apt": "custom",
+        "default": false,
+        "custom_install": "curl -Ls https://astral.sh/uv/install.sh | bash"
     }
 }


### PR DESCRIPTION
## Summary
- add Astral's uv package manager to the software list
- document uv installation in the README
- add helper aliases for uv commands

## Testing
- `ansible-playbook --syntax-check setup.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684051e0f934832ca386c63bdb0f2831