### PR TITLE
Improve README and add ansible alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ This repository contains my personal dotfiles and configurations for various env
 
 ## Setup Instructions
 
+### Dependencies
+The Ansible playbook installs all Python packages from `requirements.txt` as
+well as the CLI tools `jq` and the Azure CLI. If you prefer to run the scripts
+without using the playbook, install them manually:
+
+```bash
+pip install -r requirements.txt
+sudo apt-get install -y jq
+curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
+```
+
+`jq` and the Azure CLI are used by scripts in `bin/` such as
+`checkspotprice.sh`.
+
 ### Ansible Setup (recommended)
 1. Install Ansible (e.g. `sudo apt install ansible`).
 2. Clone the repository
@@ -116,6 +130,7 @@ These initializations are placed in ```~/.bash_exports```, which is sourced by `
 
 * **Aliases**: All aliases are organized in the bash/aliases/ directory and are sourced in ~/.bash_aliases.
   * The `uv.aliases` file provides handy shortcuts for Astral's uv package manager, such as `uvs` for `uv sync` and `uvps` for `uv pip sync`.
+  * Use `dfsetup` to run the Ansible playbook quickly: `ansible-playbook -i localhost, -c local --ask-become-pass setup.yml`.
 * **Functions**: Functions are categorized and placed in bash/functions/ and its subdirectories. They are sourced in ~/.bash_functions.
 * **Scripts**: Executable scripts are located in the bin/ directory, which is added to your PATH.
 Notes

--- a/bash/aliases/general.aliases
+++ b/bash/aliases/general.aliases
@@ -22,6 +22,10 @@ alias pip='pip3'
 alias venv='python3 -m venv'
 alias activate='source ./venv/bin/activate'
 
-# Coding aliases    
+# Coding aliases
 alias c.='code .'
 alias ci.='code-insiders .'
+
+# Dotfiles setup alias
+alias dfsetup='ansible-playbook -i localhost, -c local --ask-become-pass setup.yml'
+

--- a/setup.yml
+++ b/setup.yml
@@ -16,6 +16,29 @@
         - item.value.apt != 'custom'
       loop: "{{ software_list | dict2items }}"
 
+    - name: Install jq for helper scripts
+      become: true
+      ansible.builtin.apt:
+        name: jq
+        state: present
+
+    - name: Check for Azure CLI
+      ansible.builtin.command: az --version
+      register: azure_cli_check
+      ignore_errors: true
+
+    - name: Install Azure CLI
+      become: true
+      ansible.builtin.shell: curl -sL https://aka.ms/InstallAzureCLIDeb | bash
+      args:
+        executable: /bin/bash
+      when: azure_cli_check.rc != 0
+
+    - name: Install Python requirements
+      become: true
+      ansible.builtin.pip:
+        requirements: "{{ dotfiles_dir }}/requirements.txt"
+
     - name: Ensure ~/bin directory exists
       ansible.builtin.file:
         path: "{{ ansible_env.HOME }}/bin"


### PR DESCRIPTION
## Summary
- document required dependencies like jq and Azure CLI
- mention quick alias `dfsetup` for Ansible playbook
- add the `dfsetup` alias to `general.aliases`
- install jq, Azure CLI, and pip requirements via playbook

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68405ed9d450832c84efe401a55f944c