### PR TITLE
Fix pip missing during playbook run

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,12 @@ This repository contains my personal dotfiles and configurations for various env
 ### Dependencies
 The Ansible playbook installs all Python packages from `requirements.txt` as
 well as the CLI tools `jq` and the Azure CLI. If you prefer to run the scripts
-without using the playbook, install them manually:
+without using the playbook, install them manually. You'll need Python, pip, and
+jq installed first:
 
 ```bash
+sudo apt-get install -y python3 python3-pip jq
 pip install -r requirements.txt
-sudo apt-get install -y jq
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 

--- a/software_list.json
+++ b/software_list.json
@@ -15,7 +15,7 @@
     "python": {
         "description": "Programming language",
         "winget": "Python.Python.3",
-        "apt": "python3",
+        "apt": ["python3", "python3-pip"],
         "default": true
     },
     "7zip": {


### PR DESCRIPTION
## Summary
- install pip with python via apt
- document new python and pip dependency in README

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68406207f20c832cb5410d7a6ffff03e