### PR TITLE
Simplify README for Ansible usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,73 +1,33 @@
 # Dotfiles
-This repository contains my personal dotfiles and configurations for various environments, including local WSL (Windows Subsystem for Linux), Azure Machine Learning Compute Instances, GitHub Codespaces, and remote Linux terminals. The Ansible playbook has been tested across these setups to ensure consistent behavior.
 
-## Directory Structure
-.dotfiles/  
-├── bash/  
-│   ├── .bashrc  
-│   ├── .bash_aliases  
-│   ├── .bash_exports  
-│   ├── .bash_functions  
-│   ├── .bash_prompt  
-│   ├── aliases/  
-│   │   ├── general.aliases  
-│   │   ├── git.aliases  
-│   │   ├── docker.aliases  
-│   │   └── function_aliases.aliases  
-│   ├── completions/  
-│   │   ├── custom_env_completion.sh  
-│   │   ├── git-completion.bash  
-│   │   └── docker-completion.bash  
-│   ├── functions/  
-│   │   ├── prompt/  
-│   │   │   └── update_prompt.sh  
-│   │   ├── conda/  
-│   │   │   └── create_conda_env.sh  
-│   │   ├── azure/  
-│   │   │   └── create_aml_env.sh  
-│   │   └── utilities/  
-│   │       ├── download_verify_install.sh  
-│   │       └── extract.sh  
-│   └── scripts/  
-│       └── example_script.sh  
-├── bin/  
-│   ├── checkPrices.py  
-│   ├── checkPrices2.py  
-│   ├── enable_storage_key.sh  
-│   ├── checkspotprice.sh  
-│   └── create_azure_resources.sh  
-├── install.sh  
-├── oh-my-posh/  
-│   └── themes/  
-│       └── night-owl.omp.json  
-├── setup_linux.sh  
-├── setup_windows.sh  
-└── README.md  
+This repository stores my personal configuration files and helper scripts. The environment is managed through a single Ansible playbook that works across Windows (via WSL) and Linux hosts. Running the playbook installs all tools, links dotfiles with [GNU Stow](https://www.gnu.org/software/stow/) and configures the shell consistently.
 
-### Breakdown:
-*  bash/: Contains all Bash-related configurations and files.
-   * .bashrc: Main Bash configuration file, which sources other configuration files.
-   * .bash_aliases: Contains all your aliases, organized by category in the aliases/ directory.
-   * .bash_exports: Contains environment variable exports and initializations for tools like NVM, Neovim, and Cargo.
-   * .bash_functions: Sources all the functions from the functions/ directory.
-   * .bash_prompt: For customizing the shell prompt.
-   * aliases/: Contains categorized alias files.
-   * completions/: Contains Bash completion scripts.
-   * functions/: Contains categorized function scripts, organized into subdirectories.
-   * scripts/: Contains scripts that can be sourced or executed directly.
-* bin/: Contains executable scripts that are added to your PATH for global access.
-* install.sh, setup_linux.sh and setup_windows.sh: Deprecated shell scripts kept for reference.
-* oh-my-posh/: Contains oh-my-posh themes and configurations.
-* setup.yml: Primary Ansible playbook for setting up the environment.
-* README.md: This file.
+## Quick start
 
-## Setup Instructions
+1. Install [Ansible](https://docs.ansible.com/):
+   ```bash
+   sudo apt update && sudo apt install -y ansible
+   ```
+   On Windows you can install Ansible inside the Windows Subsystem for Linux (recommended) or
+   via `pip` in PowerShell.
+2. Clone the repository and run the playbook:
+   ```bash
+   git clone https://github.com/setuc/dotfiles.git ~/.dotfiles
+   cd ~/.dotfiles
+   ansible-playbook -i localhost, -c local --ask-become-pass setup.yml
+   ```
+   The command should be executed as your normal user. Use `--ask-become-pass` if you do not have passwordless sudo.
+
+   For a purely PowerShell workflow on Windows, run the `setup_windows.sh` script instead:
+   ```powershell
+   Set-ExecutionPolicy Bypass -Scope Process -Force
+   ./setup_windows.sh
+   ```
+   This script uses winget and Stow to replicate the Ansible configuration, but the playbook is preferred.
 
 ### Dependencies
-The Ansible playbook installs all Python packages from `requirements.txt` as
-well as the CLI tools `jq` and the Azure CLI. If you prefer to run the scripts
-without using the playbook, install them manually. You'll need Python, pip, and
-jq installed first:
+
+The playbook installs all Python packages from `requirements.txt` as well as `jq` and the Azure CLI. If you choose to run the scripts outside of Ansible, install them manually:
 
 ```bash
 sudo apt-get install -y python3 python3-pip jq
@@ -75,141 +35,21 @@ pip install -r requirements.txt
 curl -sL https://aka.ms/InstallAzureCLIDeb | sudo bash
 ```
 
-`jq` and the Azure CLI are used by scripts in `bin/` such as
-`checkspotprice.sh`.
+`jq` and the Azure CLI are required by some helper scripts in the `bin/` directory.
 
-### Ansible Setup (recommended)
-1. Install Ansible (e.g. `sudo apt install ansible`).
-2. Clone the repository
-```bash
-git clone https://github.com/setuc/dotfiles.git ~/.dotfiles
-cd ~/.dotfiles
-```
-3. Run the playbook
-```bash
-ansible-playbook -i localhost, -c local --ask-become-pass setup.yml
-```
-Run this command as your regular user; the playbook elevates privileges only
-when needed for package installation. The `--ask-become-pass` flag prompts for
-your sudo password; omit it if you have passwordless sudo.
+## Repository layout
 
-If you already have a `~/.bashrc` file, Stow may report conflicts. Back it up
-before running the playbook:
+- `bash/` – Bash configuration files, aliases, functions and completions
+- `bin/` – Helper scripts placed on the PATH
+- `ansible/` and `setup.yml` – Main playbook and roles
+- `terraform/` – Example Terraform configurations
+- Legacy shell scripts (`install.sh`, `setup_linux.sh`, `setup_windows.sh`) are retained for reference only
 
-```bash
-mv ~/.bashrc ~/.bashrc.backup
-```
-Stow can also fail on WSL if you have symlinks like `~/.aws` or `~/.azure`
-pointing to Windows paths. Temporarily move those out of the way if you see
-`Absolute/relative mismatch` errors.
+## Additional notes
 
-This playbook installs Oh My Posh into `~/bin`. The directory is created
-automatically if it does not already exist.
+- A `.pre-commit-config.yaml` is included to run `black`, `ruff` and `shellcheck`. Install [pre‑commit](https://pre-commit.com/) and run `pre-commit install` to enable automatic checks.
+- Oh My Posh is installed into `~/bin` and initialised from `.bashrc` using the theme in `oh-my-posh/themes/night-owl.omp.json`.
 
-The setup also installs Astral's `uv` package manager using its official
-installation script, which places the binary in `~/.local/bin` by default.
+---
 
-### Legacy Shell Scripts
-Legacy scripts (install.sh, setup_linux.sh, setup_windows.sh) are deprecated and kept only for reference.
-### Setting Up Oh My Posh
-Oh My Posh is initialized in the ```~/.bashrc``` file. The theme used is night-owl.omp.json, located in the ```oh-my-posh/themes/``` directory.
-
-### Conda Initialization
-The conda initialization block is automatically added to ```~/.bashrc``` by running conda init. It's important to keep this block in ```~/.bashrc``` because it's managed by Conda and may be updated automatically.
-
-
-### NVM, Neovim, and Cargo Initializations
- 
-These initializations are placed in ```~/.bash_exports```, which is sourced by ```~/.bashrc```. This keeps environment variable exports organized in one place.
-
-**Included** in``` ~/.bash_exports```:
-   * NVM Initialization: Sets up Node Version Manager and loads bash completion.
-   * Neovim Path Addition: Adds Neovim to PATH.
-   * Cargo Environment Initialization: Loads Cargo (Rust) environment variables.
-
-## Usage
-
-* **Aliases**: All aliases are organized in the bash/aliases/ directory and are sourced in ~/.bash_aliases.
-  * The `uv.aliases` file provides handy shortcuts for Astral's uv package manager, such as `uvs` for `uv sync` and `uvps` for `uv pip sync`.
-  * Use `dfsetup` to run the Ansible playbook quickly: `ansible-playbook -i localhost, -c local --ask-become-pass setup.yml`.
-* **Functions**: Functions are categorized and placed in bash/functions/ and its subdirectories. They are sourced in ~/.bash_functions.
-* **Scripts**: Executable scripts are located in the bin/ directory, which is added to your PATH.
-Notes
-
-## Using the Ansible Playbook
-
-This repository includes an Ansible playbook that can configure the local machine or a remote host with the provided dotfiles.
-
-### Run Locally
-
-1. Install Ansible
-   ```bash
-   sudo apt-get update && sudo apt-get install -y ansible
-   ```
-2. Execute the playbook
-   ```bash
-   ansible-playbook -i 'localhost,' -c local --ask-become-pass setup.yml
-   ```
-   The `--ask-become-pass` flag prompts for your sudo password; omit it if you
-   have passwordless sudo.
-
-### Run Against Remote Hosts
-
-Specify an inventory file or pass the hosts on the command line:
-
-```bash
-ansible-playbook -i inventory ansible/site.yml
-```
-
- 
-## Additional Configuration
-
-* Git configuration
-    ```bash
-    git config --global user.name "Your Name"  
-    git config --global user.email "your.email@example.com" 
-    ```
-* Nerd Fonts Installation
-installing Nerd Fonts for better terminal icons from https://github.com/ryanoasis/nerd-fonts or https://www.nerdfonts.com/.
-
-## Terraform Templates
-The `terraform/` directory contains modular templates using the
-HashiCorp [azurerm](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs)
-provider. Use these configurations to create a resource group, storage account,
-Key Vault, Application Insights, and a Machine Learning workspace.
-
-```bash
-cd terraform
-terraform init
-terraform apply -var="prefix=mydemo" -var="resource_group_name=my-rg" -var="location=eastus"
-```
-
-## Pre-commit Hooks
-A `.pre-commit-config.yaml` is included to run `black`, `ruff`, and `shellcheck`.
-Install pre-commit and run `pre-commit install` to automatically format code
-before each commit.
-
-## Custom Working Directory
-The `wd` alias now respects the `AML_CODE_DIR` environment variable so you can
-override the default Azure ML path if needed.
-
-#### TODO plan to wokr with install nerd fonts directly from the terminal. https://github.com/getnf/getnf
-
-
-
-
-## Generic Notes for me to improve
-### Linux Fresh Install
-    When working through the Azure ML VM, this is how the .bashrc file looked in the end. 
-    oh my posh was installed in 
-    cd HOME/cloudfiles/code/Users/setuchokshi/
-    mkdir bin
-    curl -s https://ohmyposh.dev/install.sh | bash -s -- -d ./bin
-    $HOME/cloudfiles/code/Users/setuchokshi/bin
-
-## BashRC in azure.
-    export PATH=$PATH:$HOME/cloudfiles/code/Users/setuchokshi/bin
-    eval "$(oh-my-posh init bash --config $HOME/.dotfiles/oh-my-posh/.poshthemes/night-owl.omp.json)"
-    if [ -f ~/.bash_aliases ]; then source ~/.bash_aliases; fi
-    for file in $HOME/.bash_completion.d/*; do source $file; done
-
+Licensed under the Unlicense. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- streamline README and highlight Ansible as the primary setup method
- document PowerShell setup script for Windows users

## Testing
- `pre-commit run --files README.md`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684066456fe4832cbd941e268002f498