### PR TITLE
Install unzip before oh-my-posh

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ You can browse other fonts at <https://www.nerdfonts.com/>.
 
 - A `.pre-commit-config.yaml` is included to run `black`, `ruff` and `shellcheck`. Install [pre‑commit](https://pre-commit.com/) and run `pre-commit install` to enable automatic checks.
 - Oh My Posh is installed into `~/bin` and initialised from `.bashrc` using the theme in `oh-my-posh/themes/night-owl.omp.json`.
+- The playbook ensures the `unzip` package is present before installing Oh My Posh.
 
 The `wd` alias defaults to the Azure ML working directory but respects the `AML_CODE_DIR` environment variable so you can override it as needed.
 

--- a/ansible/install-oh-my-posh.yml
+++ b/ansible/install-oh-my-posh.yml
@@ -2,6 +2,12 @@
 - hosts: localhost
   gather_facts: false
   tasks:
+    - name: Ensure unzip is installed
+      become: true
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+
     - name: Download oh-my-posh install script
       ansible.builtin.get_url:
         url: https://ohmyposh.dev/install.sh

--- a/ansible/roles/dotfiles/tasks/main.yml
+++ b/ansible/roles/dotfiles/tasks/main.yml
@@ -20,6 +20,13 @@
     state: directory
     mode: '0755'
 
+- name: Ensure unzip is installed for oh-my-posh
+  become: true
+  ansible.builtin.apt:
+    name: unzip
+    state: present
+  when: install_oh_my_posh | default(true)
+
 - name: Install oh-my-posh via command
   ansible.builtin.command: "{{ software_list['oh-my-posh'].custom_install }}"
   args:

--- a/setup.yml
+++ b/setup.yml
@@ -46,6 +46,12 @@
         state: directory
         mode: "0755"
 
+    - name: Ensure unzip is installed for oh-my-posh
+      become: true
+      ansible.builtin.apt:
+        name: unzip
+        state: present
+
     - name: Run custom install commands
       ansible.builtin.shell: "{{ item.value.custom_install }}"
       args:


### PR DESCRIPTION
## Summary
- ensure unzip is installed before running the Oh My Posh installer
- install unzip in setup playbook
- document that unzip is installed automatically

## Testing
- `pre-commit run --files ansible/install-oh-my-posh.yml ansible/roles/dotfiles/tasks/main.yml setup.yml README.md`
- `pytest -q`
